### PR TITLE
BUGFIX: Typo

### DIFF
--- a/src/helpers/getPokemonOptions.js
+++ b/src/helpers/getPokemonOptions.js
@@ -37,8 +37,8 @@ const getPokemonNames = async( [a,b,c,d] = [] ) => {
     return [
         { name: p1.data.name, id: p1.data.id },
         { name: p2.data.name, id: p2.data.id },
-        { name: p4.data.name, id: p3.data.id },
-        { name: p3.data.name, id: p4.data.id },
+        { name: p3.data.name, id: p3.data.id },
+        { name: p4.data.name, id: p4.data.id },
     ]
 
 }


### PR DESCRIPTION
There is a typo when creating the object of pokemon names with pokemon ids that makes the game unproperly when the correct name is on the third or fourth place.